### PR TITLE
change ivy-set-actions key from t to 'ivy-lobsters

### DIFF
--- a/ivy-lobsters.el
+++ b/ivy-lobsters.el
@@ -97,7 +97,7 @@
                           (browse-url (plist-get (cdr story) :url)))))))
 
 (ivy-set-actions
- t
+ 'ivy-lobsters
  '(("c" (lambda (story)
           (browse-url (plist-get (cdr story) :comments-url))) "Browse Comments")))
 


### PR DESCRIPTION
ref #1 
- prevents other custom actions from being blown away.

api docs - http://oremacs.com/swiper/#how-to-add-actions-to-a-specific-command
