### PR TITLE
:sparkles: add option to keep focus in Emacs

### DIFF
--- a/ivy-lobsters.el
+++ b/ivy-lobsters.el
@@ -39,6 +39,10 @@
   "Variable to define lobste.rs newest articles url."
   :type 'string :group 'ivy-lobsters)
 
+(defcustom ivy-lobsters-keep-focus nil
+  "Variable to control if the browser takes focus from Emacs.  Currently only work for macOS."
+  :type 'boolean :group 'ivy-lobsters)
+
 (defun ivy-lobsters-get-posts ()
   "Get newest posts json and store parsed stories."
   (with-temp-buffer
@@ -86,6 +90,12 @@
     (ivy-lobsters-extract 'title story))
    'utf-8))
 
+(defun ivy-lobsters-browse (url)
+  "Optionally keep focus in Emacs when opening a link.  Takes the URL as an arguement."
+  (if (and ivy-lobsters-keep-focus (eq system-type 'darwin))
+      (start-process (concat "ivy-lobsters-" url) nil "open" url "-g")
+    (browse-url url)))
+
 ;;;###autoload
 (defun ivy-lobsters ()
   "Show latest lobste.rs stories."
@@ -95,12 +105,12 @@
       (ivy-read "Lobste.rs latest stories: "
                 stories
                 :action (lambda (story)
-                          (browse-url (plist-get (cdr story) :url)))))))
+                  (ivy-lobsters-browse (plist-get (cdr story) :url)))))))
 
 (ivy-set-actions
  'ivy-lobsters
  '(("c" (lambda (story)
-          (browse-url (plist-get (cdr story) :comments-url))) "Browse Comments")))
+          (ivy-lobsters-browse (plist-get (cdr story) :url))) "Browse Comments")))
 
 
 (provide 'ivy-lobsters)


### PR DESCRIPTION
It's nice to load up a couple different links without having to switch back and forth between Emacs and my browser. Thoughts?