### PR TITLE
Load json.el for using its function

### DIFF
--- a/ivy-lobsters.el
+++ b/ivy-lobsters.el
@@ -30,6 +30,7 @@
 (require 'cl-lib)
 (require 'ivy)
 (require 'browse-url)
+(require 'json)
 
 (defgroup  ivy-lobsters nil
   "Customs for `ivy-lobsters'"


### PR DESCRIPTION
If json.el is not loaded, then a following error is occurred(however it is ignored by `ignore-error` macro)

```
Symbol’s function definition is void: json-read-from-string
```